### PR TITLE
group space ok for the bot cmd

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## 0.5.0
 
-- Add the cmmands working in the group space
+- Activate the commands in the group space
 
 ## 0.4.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.0
+
+- Add the cmmands working in the group space
+
 ## 0.4.0
 
 - Fixed issue in newer versions of the package not having `_json` field.

--- a/actions/workflows/handle_webhook.yaml
+++ b/actions/workflows/handle_webhook.yaml
@@ -14,8 +14,16 @@ cisco_spark.handle_webhook:
                 messageId: <% $.messageId %>
             publish:
                 text: <% task(get_message).result.result.text %>
-            on-success: handle_message
-        handle_message:
+                direct: <% task(get_message).result.result.roomType %>
+            on-success:
+                - direct_room: <% $.direct = 'direct' %>
+                - group_room: <% $.direct = 'group' %>
+        group_room:
+            action: chatops.run
+            input:
+                text: <% regex_replace($.text, "^[^\\s]+", "") %>
+                channel: <% $.roomId %>
+        direct_room:
             action: chatops.run
             input:
                 text: <% $.text %>

--- a/pack.yaml
+++ b/pack.yaml
@@ -7,6 +7,7 @@ keywords:
   - spark
   - video
   - chat
+  - bot
 version: 0.5.0
 author : Anthony Shaw
 email : anthonyshaw@apache.org

--- a/pack.yaml
+++ b/pack.yaml
@@ -7,6 +7,6 @@ keywords:
   - spark
   - video
   - chat
-version: 0.4.0
+version: 0.5.0
 author : Anthony Shaw
 email : anthonyshaw@apache.org


### PR DESCRIPTION
Add bot cmd as working feature in the group space by removing the bot name.
The botname should have a space between himself and the first word of the command.
No change for the direct space.
ie.:
direct space: `echo date`
group space: `@botname echo date`

Thanks for the job and the st2 session ;-)